### PR TITLE
feat: Add Spring JDBC session management support to app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,10 @@
         <java.version>17</java.version>
     </properties>
     <dependencies>
+    <dependency>
+        <groupId>org.springframework.session</groupId>
+        <artifactId>spring-session-jdbc</artifactId>
+    </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,2 @@
-
 spring.web.resources.static-locations=classpath:/public/
 spring.session.store-type=jdbc

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 
 spring.web.resources.static-locations=classpath:/public/
+spring.session.store-type=jdbc


### PR DESCRIPTION
Added the `spring-session-jdbc` dependency to the `pom.xml` file and configured the `session store type` property in the `application.properties` file to use `jdbc`. This enables the app to manage user sessions in a database-backed session store instead of memory for better scalability.